### PR TITLE
feat(invoice): allow per-order invoice mode override (#41)

### DIFF
--- a/src/Admin/OrderMetaBox.php
+++ b/src/Admin/OrderMetaBox.php
@@ -522,15 +522,40 @@ class OrderMetaBox {
 					$box.find('.ihumbak-wca-sync-order-btn').show().prop('disabled', false);
 				});
 
+				$box.on('focus', '#ihumbak-wca-invoice-mode-override', function () {
+					$(this).data('previousValue', $(this).val());
+				});
+
 				$box.on('change', '#ihumbak-wca-invoice-mode-override', function () {
 					if (syncInFlight) return;
 					var $select = $(this);
+					var previousValue = $select.data('previousValue');
 					$select.prop('disabled', true);
-					$.post(ajaxurl, {
-						action: 'ihumbak_wca_save_invoice_mode',
-						order_id: orderId,
-						mode: $select.val(),
-						ihumbak_wca_nonce: nonce
+					$.ajax({
+						url: ajaxurl,
+						type: 'POST',
+						data: {
+							action: 'ihumbak_wca_save_invoice_mode',
+							order_id: orderId,
+							mode: $select.val(),
+							ihumbak_wca_nonce: nonce
+						},
+						dataType: 'json'
+					}).done(function (response) {
+						if (response && response.success) {
+							$select.data('previousValue', $select.val());
+						} else {
+							var errorMsg = (response && response.data && response.data.message) ? response.data.message : ((response && response.data) || '<?php echo esc_js( __( 'Failed to save invoice mode.', 'ihumbak-woo-conta-api' ) ); ?>');
+							alert(errorMsg);
+							if (typeof previousValue !== 'undefined') {
+								$select.val(previousValue);
+							}
+						}
+					}).fail(function (xhr, status, error) {
+						alert('AJAX Error: ' + status + ' - ' + error);
+						if (typeof previousValue !== 'undefined') {
+							$select.val(previousValue);
+						}
 					}).always(function () {
 						$select.prop('disabled', false);
 					});

--- a/src/Admin/OrderMetaBox.php
+++ b/src/Admin/OrderMetaBox.php
@@ -74,6 +74,7 @@ class OrderMetaBox {
 		add_action( 'wp_ajax_ihumbak_wca_sync_order', [ $this, 'ajax_sync_order' ] );
 		add_action( 'wp_ajax_ihumbak_wca_manual_invoice', [ $this, 'ajax_manual_invoice' ] );
 		add_action( 'wp_ajax_ihumbak_wca_search_customers', [ $this, 'ajax_search_customers' ] );
+		add_action( 'wp_ajax_ihumbak_wca_save_invoice_mode', [ $this, 'ajax_save_invoice_mode' ] );
 	}
 
 	/**
@@ -124,6 +125,11 @@ class OrderMetaBox {
 
 		$invoice_type = $order->get_meta( InvoiceSync::META_INVOICE_TYPE );
 		$dash         = '&#8212;';
+
+		$override_mode        = (string) $order->get_meta( InvoiceSync::META_INVOICE_MODE_OVERRIDE );
+		$current_invoice_mode = in_array( $override_mode, [ 'draft', 'final' ], true )
+			? $override_mode
+			: $this->settings->get_invoice_mode();
 		?>
 		<div id="ihumbak-wca-meta-box" data-order-id="<?php echo esc_attr( (string) $order_id ); ?>">
 			<div id="ihumbak-wca-sync-overlay">
@@ -201,6 +207,18 @@ class OrderMetaBox {
 
 			<div style="margin-top:12px;">
 				<?php if ( ! $is_assigned ) : ?>
+					<p class="ihumbak-wca-invoice-mode-override-wrapper" style="margin-bottom:10px;">
+						<label for="ihumbak-wca-invoice-mode-override" style="display:block;font-weight:600;margin-bottom:2px;">
+							<?php esc_html_e( 'Invoice Mode', 'ihumbak-woo-conta-api' ); ?>
+						</label>
+						<select name="ihumbak_wca_invoice_mode_override" id="ihumbak-wca-invoice-mode-override" style="width:100%;">
+							<option value="draft" <?php selected( $current_invoice_mode, 'draft' ); ?>><?php esc_html_e( 'Draft', 'ihumbak-woo-conta-api' ); ?></option>
+							<option value="final" <?php selected( $current_invoice_mode, 'final' ); ?>><?php esc_html_e( 'Final', 'ihumbak-woo-conta-api' ); ?></option>
+						</select>
+						<small style="display:block;color:#666;margin-top:2px;">
+							<?php esc_html_e( 'Overrides the global default for this order.', 'ihumbak-woo-conta-api' ); ?>
+						</small>
+					</p>
 					<button type="button"
 						class="button button-primary ihumbak-wca-sync-order-btn"
 						style="width:100%;margin-bottom:8px;">
@@ -319,6 +337,8 @@ class OrderMetaBox {
 						ihumbak_wca_nonce: nonce
 					};
 
+					postData.invoice_mode_override = $box.find('#ihumbak-wca-invoice-mode-override').val();
+
 					if (selectedCustomerId > 0) {
 						postData.selected_customer_id = selectedCustomerId;
 					}
@@ -347,6 +367,9 @@ class OrderMetaBox {
 								}
 								$box.find('#ihumbak-wca-error').remove();
 								$box.find('.ihumbak-wca-sync-order-btn').remove();
+								if (response.data.invoice_id) {
+									$box.find('.ihumbak-wca-invoice-mode-override-wrapper').remove();
+								}
 								$box.find('#ihumbak-wca-customer-selection').empty().hide();
 								if (response.data.error) {
 									$box.find('table').after(
@@ -499,6 +522,20 @@ class OrderMetaBox {
 					$box.find('.ihumbak-wca-sync-order-btn').show().prop('disabled', false);
 				});
 
+				$box.on('change', '#ihumbak-wca-invoice-mode-override', function () {
+					if (syncInFlight) return;
+					var $select = $(this);
+					$select.prop('disabled', true);
+					$.post(ajaxurl, {
+						action: 'ihumbak_wca_save_invoice_mode',
+						order_id: orderId,
+						mode: $select.val(),
+						ihumbak_wca_nonce: nonce
+					}).always(function () {
+						$select.prop('disabled', false);
+					});
+				});
+
 				$box.on('click', '#ihumbak-wca-manual-toggle', function(e) {
 					e.preventDefault();
 					$('#ihumbak-wca-manual-form').slideToggle(200);
@@ -596,6 +633,14 @@ class OrderMetaBox {
 		$selected_customer_id  = isset( $_POST['selected_customer_id'] ) ? absint( $_POST['selected_customer_id'] ) : 0;
 		$force_create_customer = ! empty( $_POST['force_create_customer'] );
 
+		if ( isset( $_POST['invoice_mode_override'] ) ) {
+			$posted_mode = sanitize_text_field( wp_unslash( $_POST['invoice_mode_override'] ) );
+			if ( in_array( $posted_mode, [ 'draft', 'final' ], true ) ) {
+				$order->update_meta_data( InvoiceSync::META_INVOICE_MODE_OVERRIDE, $posted_mode );
+				$order->save();
+			}
+		}
+
 		$result = $this->invoice_sync->sync_order( $order, '', $selected_customer_id, $force_create_customer );
 
 		if ( is_wp_error( $result ) ) {
@@ -618,6 +663,7 @@ class OrderMetaBox {
 				'invoice_id'     => (string) $order->get_meta( InvoiceSync::META_INVOICE_ID ),
 				'invoice_no'     => (string) $order->get_meta( InvoiceSync::META_INVOICE_NO ),
 				'invoice_type'   => (string) $order->get_meta( InvoiceSync::META_INVOICE_TYPE ),
+				'invoice_mode'   => (string) $order->get_meta( InvoiceSync::META_INVOICE_MODE ),
 				'customer_id'    => (string) $order->get_meta( CustomerSync::META_CUSTOMER_ID ),
 				'sync_date'      => (string) $order->get_meta( InvoiceSync::META_SYNC_DATE ),
 				'error'          => is_string( $sync_error ) && '' !== $sync_error ? $sync_error : '',
@@ -739,6 +785,46 @@ class OrderMetaBox {
 				'count'         => count( $customers ),
 			]
 		);
+	}
+
+	/**
+	 * AJAX handler for saving a per-order invoice mode override.
+	 *
+	 * @return void
+	 */
+	public function ajax_save_invoice_mode(): void {
+		check_ajax_referer( 'ihumbak_wca_meta_box', 'ihumbak_wca_nonce' );
+
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_send_json_error( __( 'Permission denied.', 'ihumbak-woo-conta-api' ), 403 );
+		}
+
+		$order_id = isset( $_POST['order_id'] ) ? absint( $_POST['order_id'] ) : 0;
+
+		if ( 0 === $order_id ) {
+			wp_send_json_error( __( 'Invalid order ID.', 'ihumbak-woo-conta-api' ), 400 );
+		}
+
+		$order = wc_get_order( $order_id );
+
+		if ( ! $order instanceof WC_Order ) {
+			wp_send_json_error( __( 'Order not found.', 'ihumbak-woo-conta-api' ), 404 );
+		}
+
+		if ( $this->invoice_sync->is_synced( $order ) ) {
+			wp_send_json_error( __( 'Invoice already synced.', 'ihumbak-woo-conta-api' ), 409 );
+		}
+
+		$mode = isset( $_POST['mode'] ) ? sanitize_text_field( wp_unslash( $_POST['mode'] ) ) : '';
+
+		if ( ! in_array( $mode, [ 'draft', 'final' ], true ) ) {
+			wp_send_json_error( __( 'Invalid invoice mode.', 'ihumbak-woo-conta-api' ), 400 );
+		}
+
+		$order->update_meta_data( InvoiceSync::META_INVOICE_MODE_OVERRIDE, $mode );
+		$order->save();
+
+		wp_send_json_success( [ 'saved_mode' => $mode ] );
 	}
 
 	/**

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -315,8 +315,8 @@ class SettingsPage {
 			[
 				'type'    => 'select',
 				'id'      => 'ihumbak_wca_invoice_mode',
-				'name'    => __( 'Invoice Mode', 'ihumbak-woo-conta-api' ),
-				'desc'    => __( 'Draft creates an editable invoice draft in Conta. Final creates a finalized invoice immediately.', 'ihumbak-woo-conta-api' ),
+				'name'    => __( 'Default Invoice Mode', 'ihumbak-woo-conta-api' ),
+				'desc'    => __( 'Default mode applied to new orders. Draft creates an editable invoice draft in Conta. Final creates a finalized invoice immediately. Each order can override this on its edit screen.', 'ihumbak-woo-conta-api' ),
 				'options' => [
 					'draft' => __( 'Draft', 'ihumbak-woo-conta-api' ),
 					'final' => __( 'Final', 'ihumbak-woo-conta-api' ),

--- a/src/Modules/InvoiceSync.php
+++ b/src/Modules/InvoiceSync.php
@@ -378,7 +378,9 @@ class InvoiceSync {
 		 * @param string   $mode  Resolved mode: 'draft' or 'final'.
 		 * @param WC_Order $order The WooCommerce order being synced.
 		 */
-		return (string) apply_filters( 'ihumbak_wca_invoice_mode_for_order', $mode, $order );
+		$filtered = (string) apply_filters( 'ihumbak_wca_invoice_mode_for_order', $mode, $order );
+
+		return in_array( $filtered, [ 'draft', 'final' ], true ) ? $filtered : $mode;
 	}
 
 	/**

--- a/src/Modules/InvoiceSync.php
+++ b/src/Modules/InvoiceSync.php
@@ -72,6 +72,15 @@ class InvoiceSync {
 	public const META_INVOICE_MODE = '_ihumbak_wca_invoice_mode';
 
 	/**
+	 * Order meta key for the per-order invoice mode override
+	 * (Draft / Final). When unset, the global Settings::get_invoice_mode()
+	 * default applies.
+	 *
+	 * @var string
+	 */
+	public const META_INVOICE_MODE_OVERRIDE = '_ihumbak_wca_invoice_mode_override';
+
+	/**
 	 * Invoices API endpoint.
 	 *
 	 * @var Invoices
@@ -196,7 +205,7 @@ class InvoiceSync {
 		$invoice       = Invoice::from_wc_order( $order, $customer_id, $this->vat_mapper, $this->settings );
 		$invoice->type = $invoice_type;
 
-		$is_draft = $this->settings->is_draft_mode();
+		$is_draft = 'draft' === $this->resolve_invoice_mode( $order );
 
 		if ( $is_draft ) {
 			$data = $invoice->to_draft_array();
@@ -345,6 +354,31 @@ class InvoiceSync {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Resolve the effective invoice mode for a specific order.
+	 *
+	 * Checks per-order override first, falls back to the global setting,
+	 * then applies the `ihumbak_wca_invoice_mode_for_order` filter.
+	 *
+	 * @param WC_Order $order The WooCommerce order being synced.
+	 * @return string Resolved mode: 'draft' or 'final'.
+	 */
+	private function resolve_invoice_mode( WC_Order $order ): string {
+		$override = (string) $order->get_meta( self::META_INVOICE_MODE_OVERRIDE );
+		$mode     = in_array( $override, [ 'draft', 'final' ], true )
+			? $override
+			: $this->settings->get_invoice_mode();
+		/**
+		 * Filter the invoice mode resolved for a specific order.
+		 *
+		 * Applied after per-order override and global default fallback.
+		 *
+		 * @param string   $mode  Resolved mode: 'draft' or 'final'.
+		 * @param WC_Order $order The WooCommerce order being synced.
+		 */
+		return (string) apply_filters( 'ihumbak_wca_invoice_mode_for_order', $mode, $order );
 	}
 
 	/**

--- a/uninstall.php
+++ b/uninstall.php
@@ -21,18 +21,27 @@ delete_option( 'ihumbak_wca_settings' );
 if ( apply_filters( 'ihumbak_wca_uninstall_remove_order_meta', false ) ) {
 	global $wpdb;
 
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-	$wpdb->delete(
-		$wpdb->prefix . 'postmeta',
-		[ 'meta_key' => '_ihumbak_wca_invoice_id' ] // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-	);
+	$ihumbak_wca_meta_keys = [
+		'_ihumbak_wca_invoice_id',
+		'_ihumbak_wca_invoice_mode_override',
+	];
+
+	foreach ( $ihumbak_wca_meta_keys as $ihumbak_wca_meta_key ) {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->delete(
+			$wpdb->prefix . 'postmeta',
+			[ 'meta_key' => $ihumbak_wca_meta_key ] // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		);
+	}
 
 	// HPOS meta table.
 	if ( $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}wc_orders_meta'" ) === $wpdb->prefix . 'wc_orders_meta' ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$wpdb->delete(
-			$wpdb->prefix . 'wc_orders_meta',
-			[ 'meta_key' => '_ihumbak_wca_invoice_id' ] // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-		);
+		foreach ( $ihumbak_wca_meta_keys as $ihumbak_wca_meta_key ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->delete(
+				$wpdb->prefix . 'wc_orders_meta',
+				[ 'meta_key' => $ihumbak_wca_meta_key ] // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			);
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Adds a Draft/Final selector to the order meta box that overrides the global `ihumbak_wca_invoice_mode` setting per order. The override is stored in a new `_ihumbak_wca_invoice_mode_override` meta key and is honoured by the manual sync button, the Action Scheduler async path, and the bulk action.
- Introduces `InvoiceSync::resolve_invoice_mode()` plus a new `ihumbak_wca_invoice_mode_for_order` filter for programmatic overrides. The existing `_ihumbak_wca_invoice_mode` meta continues to record the actual mode used at sync time.
- Settings page wording renamed to "Default Invoice Mode" to clarify it is the default applied to new orders; `uninstall.php` extended to clean up the new meta key.

Closes #41.

## Test plan
- [ ] Unsynced order shows the "Invoice Mode" selector above "Create Invoice"; default matches the global setting.
- [ ] Changing the selector persists across page reload (saved via new `ihumbak_wca_save_invoice_mode` AJAX endpoint).
- [ ] With global = `draft` and per-order override = `final`, syncing creates a finalized invoice in Conta; `_ihumbak_wca_invoice_mode` is recorded as `final`. Inverse case also works.
- [ ] Selector disappears once an invoice exists for the order.
- [ ] Async path (Action Scheduler `ihumbak_wca_sync_invoice`) honours the per-order override.
- [ ] Bulk "Sync to Conta" action honours each order's individual override.
- [ ] `add_filter('ihumbak_wca_invoice_mode_for_order', fn() => 'final')` overrides both per-order meta and the global default.
- [ ] Foreign-currency order with override = `final` still maps to `invoice_type = NORMAL` and triggers payment auto-sync.
- [ ] AJAX `ihumbak_wca_save_invoice_mode` returns 409 for an already-synced order; 403 without `manage_woocommerce`; 400 for an invalid `mode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)